### PR TITLE
Add file seek, bugfix PCM::position(), upgrade player

### DIFF
--- a/include/capo/music.hpp
+++ b/include/capo/music.hpp
@@ -33,7 +33,7 @@ class Music {
 	///
 	/// \brief Open a file at path for streaming
 	///
-	Result<void> open(std::string path);
+	Result<void> open(std::string_view path);
 	///
 	/// \brief Preload pcm for streaming
 	///

--- a/include/capo/pcm.hpp
+++ b/include/capo/pcm.hpp
@@ -35,15 +35,14 @@ struct PCM {
 class PCM::Streamer {
   public:
 	Streamer();
-	Streamer(std::string path);
+	Streamer(std::string_view path);
 	Streamer(PCM pcm);
 	Streamer(Streamer&&) noexcept;
 	Streamer& operator=(Streamer&&) noexcept;
 	~Streamer() noexcept;
 
-	Result<void> open(std::string path);
+	Result<void> open(std::string_view path);
 	void preload(PCM pcm) noexcept;
-	Result<void> reopen();
 	bool valid() const noexcept;
 	explicit operator bool() const noexcept { return valid(); }
 

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -28,9 +28,9 @@ Music::~Music() = default;
 bool Music::valid() const noexcept { return m_instance && m_instance->valid(); }
 bool Music::ready() const { return valid() && m_impl->stream.ready(); }
 
-Result<void> Music::open(std::string path) {
+Result<void> Music::open(std::string_view path) {
 	if (valid()) {
-		if (m_impl->stream.open(std::move(path))) { return Result<void>::success(); }
+		if (m_impl->stream.open(path)) { return Result<void>::success(); }
 		return Error::eIOError;
 	}
 	return Error::eInvalidValue;


### PR DESCRIPTION
Notes:
- Fix `PCM::Streamer::position()` : multiply by total duration 😛
- Replace `reopen()` calls with `seek({})` to circumvent redundant reloads (user can explicitly `open()` a file again if needed instead)
- Remove `reopen()` and need to store `path`
- Refactor `std::string`s for above to `std::string_view`s
- Simplify `DrFormat`: eliminate need to specify exact function signatures by using a facade of (templated) function pointers + deduction guide
- Upgrade music player to allow streaming / preloading, and use first argument as option to control it

Close #34 